### PR TITLE
Fix bulk API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+# 1.2.13.fix-bulk (2016-01-10)
+- fix issues with bulk api request generation

--- a/README.md
+++ b/README.md
@@ -56,12 +56,15 @@ Or install it yourself as:
 
 ## Updating
 
-Create a branch off of master and make your changes.
-- eg: ```git checkout -b fix_bulk```
-Create a pull request for review.
-Once reviewed and merged, pull the latest master and update version.rb. The major, minor and patch versions match the version of Biffbot itself and should not be changed except for updates. Update the number at the end.
-Commit the changes and push, ```git commit -m "Release vX.X.X.descriptive.name" && git push origin master```.
-Tag the release and push, git tag vX.X.X.descriptive.name && git push --tags.
+- Create a branch off of master and make your changes.
+ - eg: ```git checkout -b fix_bulk```
+- Create a pull request for review.
+- Once reviewed and merged, pull the latest master and update version.rb. The major, minor and patch versions match the version of Biffbot itself and should not be changed except for updates. Update the number at the end.
+- Commit the changes and push
+ - ```git commit -m "Release vX.X.X.descriptive.name" && git push origin master```
+- Tag the release and push, git tag vX.X.X.descriptive.name && git push --tags.
  - eg: v1.2.13.fix.bulk
-Build the gem via ```gem build biffbot.gemspec```.
-Push the gem to Gemfury ```fury push biffbot-1.2.13.fix.pre.bulk.gem --as=doximity```.
+- Build the gem
+ - ```gem build biffbot.gemspec```.
+- Push the gem to Gemfury 
+ - ```fury push biffbot-1.2.13.fix.pre.bulk.gem --as=doximity```.

--- a/README.md
+++ b/README.md
@@ -54,10 +54,14 @@ Or install it yourself as:
 
 3. Style matters, check your rubocop output. 
 
-## Contributing
+## Updating
 
-1. Fork it
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
+Create a branch off of master and make your changes.
+- eg: ```git checkout -b fix_bulk```
+Create a pull request for review.
+Once reviewed and merged, pull the latest master and update version.rb. The major, minor and patch versions match the version of Biffbot itself and should not be changed except for updates. Update the number at the end.
+Commit the changes and push, ```git commit -m "Release vX.X.X.descriptive.name" && git push origin master```.
+Tag the release and push, git tag vX.X.X.descriptive.name && git push --tags.
+ - eg: v1.2.13.fix.bulk
+Build the gem via ```gem build biffbot.gemspec```.
+Push the gem to Gemfury ```fury push biffbot-1.2.13.fix.pre.bulk.gem --as=doximity```.

--- a/lib/biffbot/base.rb
+++ b/lib/biffbot/base.rb
@@ -65,6 +65,8 @@ module Biffbot
     # @param request [String] The url to append options to
     # @return [String] a formatted url with options merged into the input url
     def parse_options options = {}, request = ''
+      uri = request.present? ? Addressable::URI.parse(request) : diffbot_url
+
       options.each do |opt, value|
         if opt.is_a?(Array)
           diffbot_query_params[opt.to_sym] = diffbot_query_params[opt.to_sym].push(value).flatten.uniq
@@ -77,9 +79,9 @@ module Biffbot
         diffbot_query_params[key] = value.join(',') if value.is_a?(Array)
       end
 
-      diffbot_url.query_values = diffbot_query_params
+      uri.query_values = diffbot_query_params
 
-      diffbot_url
+      uri
     end
   end
 end

--- a/lib/biffbot/bulk.rb
+++ b/lib/biffbot/bulk.rb
@@ -2,6 +2,7 @@ require 'httparty'
 require 'json'
 require 'hashie'
 require 'cgi'
+
 module Biffbot
   class Bulk < Base
     include Hashie::Extensions::Coercion
@@ -22,10 +23,9 @@ module Biffbot
     def create_job name, api_type, urls = [], options = {}
       api_url = "http://api.diffbot.com/v2/#{api_type}"
       api_url = "http://api.diffbot.com/#{options[:version]}/#{api_type}" if options[:version] == 'v2' || options[:version] == 'v3'
-      api_url = parse_options(options, api_url)
+      api_url = parse_options(options, api_url).display_uri.to_s
       endpoint = 'http://api.diffbot.com/v3/bulk'
       post_body = generate_post_body(name, api_url, urls, options)
-
       www_form_encoded_body = URI.encode_www_form(post_body)
 
       JSON.parse(HTTParty.post(endpoint, body: www_form_encoded_body, headers: {'Content-Type' => 'application/x-www-form-urlencoded'}).body).each_pair do |k, v|

--- a/lib/biffbot/version.rb
+++ b/lib/biffbot/version.rb
@@ -1,3 +1,3 @@
 module Biffbot
-  VERSION = '1.2.13'
+  VERSION = '1.2.13.fix-bulk'
 end


### PR DESCRIPTION
The parse_options method in the base class takes a request param. It was modified in a previous change but the existing behaviour was not accounted for. Resotring that existing behaviour with this change and also adding documentation for how to create release gem version so gem changes can be QA'd.